### PR TITLE
jsonpb: ignore unexported fields when serializing

### DIFF
--- a/jsonpb/jsonpb.go
+++ b/jsonpb/jsonpb.go
@@ -301,6 +301,11 @@ func (m *Marshaler) marshalObject(out *errWriter, v proto.Message, indent, typeU
 			continue
 		}
 
+		// Ignore unexported fields.
+		if valueField.PkgPath != "" {
+			continue
+		}
+
 		// IsNil will panic on most value kinds.
 		switch value.Kind() {
 		case reflect.Chan, reflect.Func, reflect.Interface:


### PR DESCRIPTION
This makes serialization work with newer versions of protobuf bindings,
which renamed the previously exported XXX_* fields to unexported fields.